### PR TITLE
Fix loading of a JSON file

### DIFF
--- a/depthai_pipeline_graph/pipeline_graph.py
+++ b/depthai_pipeline_graph/pipeline_graph.py
@@ -129,7 +129,7 @@ class PipelineGraph:
     def cmd_tool(self, args):
         if args.action == "load":
             self.graph_widget.show()
-            self.graph.load_session(args.json)
+            self.graph.load_session(args.json_file)
             self.graph.fit_to_selection()
             self.graph.set_zoom(-0.9)
             self.graph.clear_selection()


### PR DESCRIPTION
So it doesn't produce errors like:
```
$ pipeline_graph load pipeline.json 
Traceback (most recent call last):
  File ".../.venv/bin/pipeline_graph", line 33, in <module>
    sys.exit(load_entry_point('depthai-pipeline-graph==0.0.5', 'console_scripts', 'pipeline_graph')())
  File ".../.venv/lib/python3.10/site-packages/depthai_pipeline_graph/pipeline_graph.py", line 375, in main
    p.cmd_tool(args)
  File ".../.venv/lib/python3.10/site-packages/depthai_pipeline_graph/pipeline_graph.py", line 132, in cmd_tool
    self.graph.load_session(args.json)
AttributeError: 'Namespace' object has no attribute 'json'
```